### PR TITLE
CORS Middleware

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,9 +5,10 @@ import litellm, json, os
 load_dotenv(dotenv_path=".env", override=True)
 
 
-access_keys = json.loads(os.getenv("ACCESS_KEYS"))
+access_keys = json.loads(os.getenv("ACCESS_KEYS", "[]"))
+origins = json.loads(os.getenv("ALLOWED_ORIGINS", "[]"))
+
+rates = ["3/second", "60/minute", "3000/day"]
 
 litellm.success_callback = ["langfuse"]
 litellm.failure_callback = ["langfuse"]
-
-rates = ["3/second", "60/minute", "3000/day"]

--- a/main.py
+++ b/main.py
@@ -1,8 +1,8 @@
-from config import rates
+from config import rates, origins
 
 from fastapi import FastAPI, Response
 
-from src.security import auth, limits
+from src.security import auth, limits, cors
 from src.endpoints import ai, test
 
 
@@ -12,6 +12,7 @@ app.include_router(ai.router)
 app.include_router(test.router)
 
 limits.setup(app, rates)
+cors.setup(app, origins)
 
 
 @app.get("/", dependencies=[auth.via_api_key])

--- a/src/security/cors.py
+++ b/src/security/cors.py
@@ -1,0 +1,12 @@
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi import FastAPI
+
+
+def setup(app: FastAPI, allowed_origins: list[str]):
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=allowed_origins,
+        allow_credentials=False,
+        allow_methods=["GET", "POST"],
+        allow_headers=["x-api-key", "content-type"],
+    )


### PR DESCRIPTION
## [Add cors middleware defaulting to no allowed origins](https://github.com/emilrueh/overlord/commit/e059c9cd5a91d9910b516e9abf770e028f78b0e6)

- security layer essentially blocking anything that is not whitelisted from accessing the api e.g. domains, headers, methods, etc.
- for now defaulting to no domains being allowed as all traffic is coming from direct requests e.g. python requests
- only used methods and headers are added

Check out documentation: https://fastapi.tiangolo.com/tutorial/cors/