### PR TITLE
Chat feature implementation through api and client overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,47 @@
 
 ---
 
-# Client
+# 🤖 Server
+
+## Setup
+
+### Secrets
+
+```env
+APP_NAME="my-overlord"
+ACCESS_KEYS='["example-secret-key-one", "example-secret-key-two", "example-secret-key-three"]'
+ALLOWED_ORIGINS='["https://www.example.com/"]'
+RATE_LIMITS='["1/second", "10/minute", "100/day"]'
+
+# various langfuse project keys
+LANGFUSE_SECRET_KEY_PROJECT="your-langfuse-secret-key-with-the-project-name"
+LANGFUSE_PUBLIC_KEY_PROJECT="your-langfuse-public-key-with-the-project-name"
+
+# various ai provider api keys
+OPENAI_API_KEY="your-openai-api-key"
+ANTHROPIC_API_KEY="your-anthropic-api-key"
+GEMINI_API_KEY="your-gemini-api-key"
+```
+
+### Deployment
+
+#### Local
+
+`pip install -r requirements.txt`
+
+`uvicorn main:app --no-access-log`
+
+#### Cloud
+
+Simply utilize the `Dockerfile` to automatically install all dependencies.
+
+### Usage
+
+Currently there only is a Python client available for server to server communication.
+
+The Overlord API is based on server-sent events (SSE), meaning by simply sending requests to the `ai/chat` endpoint and parsing SSE one could access the API easily and build their own client for front-end usage in e.g. JavaScript etc.
+
+# 😊 Client
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
         <img src="overlord.png" alt="" width="420">
     </a>
 </div>
+
+---
+
+Client usage documentation: https://gist.github.com/emilrueh/f06cd7ca898faf41745d6620df6f7a41

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
     - [Request](#request)
   - [Notes](#notes)
 
----
+&nbsp;
 
 # 🤖 Server
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Run `pip install requests pydantic langfuse`
 from overlordapi import Overlord
 
 overlord = Overlord("http://your-server.url", "your-api-key", "your-langfuse-project")
+
+# health check (optional)
+print(overlord.client.ping().text)
 ```
 
 ### Input
@@ -98,6 +101,10 @@ data = overlord.input(prompt="What did we just look at?")
 #### Persistant chat
 ```python
 chat = overlord.chat()
+
+# check session id (optional)
+print(chat.session_id)
+
 response = chat.request(data)
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,4 +6,101 @@
 
 ---
 
-Client usage documentation: https://gist.github.com/emilrueh/f06cd7ca898faf41745d6620df6f7a41
+# Client
+
+## Setup
+
+### Secrets
+
+```env
+OVERLORD_API_KEY="your-api-key"
+LANGFUSE_PUBLIC_KEY="your-api-key"
+LANGFUSE_SECRET_KEY="your-api-key"
+```
+
+### Installation
+
+Copy `client.py` to your project directory.
+Rename the file to: `overlordapi.py`
+
+## Usage
+
+```python
+from overlordapi import Overlord
+
+overlord = Overlord("http://your-server-url", "your-api-key", "your-langfuse-project")
+```
+
+### Input
+
+The API can be called with either a prompt from Langfuse or a simple text prompt.
+Every chat must however start with a Langfuse prompt, as model settings are derived from it.
+
+```python
+class ChatInput(BaseModel):
+    prompt: str | dict
+    file_urls: list[str] = []  # optional
+    metadata: dict = {}  # custom
+
+# overlord.input internalizes this schema
+```
+
+#### Langfuse prompt
+
+Here are the internalized models shown to visualize the dictionary structure required by ChatInput's prompt.
+
+```python
+class PromptArgs(BaseModel):
+    name: str
+    label: str  # defaults to 'production'
+    version: str | None = None
+
+
+class PromptConfig(BaseModel):
+    args: PromptArgs
+    project: str  # this is set internally in the PromptManager and can be ignored
+    placeholders: dict = {}  # optional
+```
+
+```python
+data = overlord.input(
+    prompt=dict(
+        args=dict(
+            name="summarize_file",
+            label="latest",
+        ),
+        placeholders=dict(
+            role="professor",
+        ),
+    ),
+    file_urls=["https://constitutioncenter.org/media/files/constitution.pdf"],
+    metadata=dict(
+        order_id="123456",
+    ),
+)
+```
+
+#### Simple text prompt
+
+As mentioned earlier the chat can be continued with a simple text prompt but must always start with a Langfuse prompt.
+
+```python
+data = overlord.input(prompt="What did we just look at?")
+```
+
+### Request
+
+#### Persistant chat
+```python
+chat = overlord.chat()
+response = chat.request(data)
+```
+
+#### Single task
+```python
+response = overlord.chat().request(data)
+```
+
+## Notes
+- the initally provided json schema from the first Langfuse prompt is used throughout a chat
+- every chat will have its own session id used to connect messages in the Langfuse UI

--- a/README.md
+++ b/README.md
@@ -14,21 +14,26 @@
 
 ```env
 OVERLORD_API_KEY="your-api-key"
+OVERLORD_SERVER_URL="https://the-server.url"
+
 LANGFUSE_PUBLIC_KEY="your-api-key"
 LANGFUSE_SECRET_KEY="your-api-key"
 ```
 
 ### Installation
 
-Copy `client.py` to your project directory.
-Rename the file to: `overlordapi.py`
+Copy `client.py` to your cwd
+
+Rename to `overlordapi.py`
+
+Run `pip install requests pydantic langfuse`
 
 ## Usage
 
 ```python
 from overlordapi import Overlord
 
-overlord = Overlord("http://your-server-url", "your-api-key", "your-langfuse-project")
+overlord = Overlord("http://your-server.url", "your-api-key", "your-langfuse-project")
 ```
 
 ### Input

--- a/README.md
+++ b/README.md
@@ -6,6 +6,24 @@
 
 ---
 
+> FastAPI integrating LiteLLM's flexibility with Langfuse's prompt management.
+
+# Table of Contents
+- [Server](#🤖-server)
+  - [Setup](#setup)
+    - [Secrets](#secrets)
+    - [Deployment](#deployment)
+  - [Usage](#usage)
+- [Client](#😊-client)
+  - [Setup](#setup-1)
+    - [Installation](#installation)
+  - [Usage](#usage-1)
+    - [Input](#input)
+    - [Request](#request)
+  - [Notes](#notes)
+
+---
+
 # 🤖 Server
 
 ## Setup
@@ -127,7 +145,7 @@ As mentioned earlier the chat can be continued with a simple text prompt but mus
 data = overlord.input(prompt="What did we just look at?")
 ```
 
-### Request
+### Requests
 
 #### Single task
 ```python

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ overlord = Overlord("http://your-server.url", "your-api-key", "your-langfuse-pro
 print(overlord.client.ping().text)
 ```
 
+### Create Langfuse prompt
+
+
+
 ### Input
 
 The API can be called with either a prompt from Langfuse or a simple text prompt.
@@ -100,7 +104,7 @@ data = overlord.input(prompt="What did we just look at?")
 
 #### Single task
 ```python
-response = overlord.chat().request(data)
+response = overlord.task(data)
 ```
 
 #### Persistant chat

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ class PromptArgs(BaseModel):
 class PromptConfig(BaseModel):
     args: PromptArgs
     placeholders: dict = {}  # optional
-    _project: str  # this is used internally and can be ignored
+    project: str  # this is used internally and can be ignored
 ```
 
 ```python

--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ data = overlord.input(prompt="What did we just look at?")
 
 ### Request
 
+#### Single task
+```python
+response = overlord.chat().request(data)
+```
+
 #### Persistant chat
 ```python
 chat = overlord.chat()
@@ -106,11 +111,6 @@ chat = overlord.chat()
 print(chat.session_id)
 
 response = chat.request(data)
-```
-
-#### Single task
-```python
-response = overlord.chat().request(data)
 ```
 
 ## Notes

--- a/README.md
+++ b/README.md
@@ -10,13 +10,6 @@
 
 ## Setup
 
-### Secrets
-
-```env
-OVERLORD_API_KEY="your-api-key"
-OVERLORD_SERVER_URL="https://the-server.url"
-```
-
 ### Installation
 
 Copy `client.py` to your cwd
@@ -112,5 +105,5 @@ response = chat.request(data)
 ```
 
 ## Notes
-- the initally provided json schema from the first Langfuse prompt is used throughout a chat
 - every chat will have its own session id used to connect messages in the Langfuse UI
+- the initally provided system prompt json schema from the first Langfuse prompt is used throughout a chat

--- a/README.md
+++ b/README.md
@@ -15,9 +15,6 @@
 ```env
 OVERLORD_API_KEY="your-api-key"
 OVERLORD_SERVER_URL="https://the-server.url"
-
-LANGFUSE_PUBLIC_KEY="your-api-key"
-LANGFUSE_SECRET_KEY="your-api-key"
 ```
 
 ### Installation
@@ -26,22 +23,19 @@ Copy `client.py` to your cwd
 
 Rename to `overlordapi.py`
 
-Run `pip install requests pydantic langfuse`
+Run `pip install requests pydantic`
 
 ## Usage
 
 ```python
 from overlordapi import Overlord
 
+
 overlord = Overlord("http://your-server.url", "your-api-key", "your-langfuse-project")
 
 # health check (optional)
 print(overlord.client.ping().text)
 ```
-
-### Create Langfuse prompt
-
-
 
 ### Input
 
@@ -70,8 +64,8 @@ class PromptArgs(BaseModel):
 
 class PromptConfig(BaseModel):
     args: PromptArgs
-    project: str  # this is set internally in the PromptManager and can be ignored
     placeholders: dict = {}  # optional
+    _project: str  # this is used internally and can be ignored
 ```
 
 ```python

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ data = overlord.input(prompt="What did we just look at?")
 response = overlord.task(data)
 ```
 
-#### Persistant chat
+#### Persistent chat
 ```python
 chat = overlord.chat()
 

--- a/client.py
+++ b/client.py
@@ -243,7 +243,7 @@ class Chat:
             is_new_lf_prompt = self._handle_lf_prompt_config(prompt_data)
 
         chat_request = ChatRequest(
-            lf_prompt_config=self._active_lf_prompt_config or self._initial_lf_prompt_config,
+            lf_prompt_config=self._active_lf_prompt_config or self._initial_lf_prompt_config,  # fallback to first lf prompt
             is_new_lf_prompt=is_new_lf_prompt,
             text_prompt=None if isinstance(prompt_data, dict) else prompt_data,
             message_history=self._message_history,
@@ -255,7 +255,7 @@ class Chat:
         try:
             response = next(self._overlord._client.request(self._endpoint, "POST", chat_request.model_dump()))
         except:
-            self._active_lf_prompt_config = None
+            self._active_lf_prompt_config = None  # reset for clean retry
             raise
 
         # only set json schema from first lf prompt

--- a/client.py
+++ b/client.py
@@ -296,7 +296,7 @@ class Overlord:
 
     # 2. single request
     data = overlord.input(...)
-    response = overlord.chat().request(data)
+    response = overlord.task(data)
     ```
     """
 
@@ -307,3 +307,6 @@ class Overlord:
 
     def chat(self):
         return Chat(self)
+
+    def task(self, data):
+        return self.chat().request(data)

--- a/client.py
+++ b/client.py
@@ -20,8 +20,8 @@ class PromptArgs(BaseModel):
 
 class PromptConfig(BaseModel):
     args: PromptArgs
-    project: str
     placeholders: dict = {}
+    _project: str
 
 
 def prepare_prompt(project, args, placeholders=[]) -> PromptConfig:
@@ -31,7 +31,7 @@ def prepare_prompt(project, args, placeholders=[]) -> PromptConfig:
             label=args["label"],
             version=args.get("version"),
         ),
-        project=project,
+        _project=project,
     )
 
     if placeholders:

--- a/client.py
+++ b/client.py
@@ -21,7 +21,7 @@ class PromptArgs(BaseModel):
 class PromptConfig(BaseModel):
     args: PromptArgs
     placeholders: dict = {}
-    _project: str
+    project: str
 
 
 def prepare_prompt(project, args, placeholders=[]) -> PromptConfig:
@@ -31,7 +31,7 @@ def prepare_prompt(project, args, placeholders=[]) -> PromptConfig:
             label=args["label"],
             version=args.get("version"),
         ),
-        _project=project,
+        project=project,
     )
 
     if placeholders:
@@ -191,7 +191,7 @@ class Chat:
         self._active_lf_prompt_config = None
 
     def _handle_lf_prompt_config(self, prompt_data) -> bool:
-        prompt_config = prepare_prompt(self._overlord._project, **prompt_data)
+        prompt_config = prepare_prompt(self._overlord.project, **prompt_data)
 
         if prompt_config != self._active_lf_prompt_config:
             self._active_lf_prompt_config = prompt_config
@@ -268,7 +268,7 @@ class Overlord:
     def __init__(self, server, api_key, project):
         self.client = _Client(server, api_key)
         self.input = ChatInput
-        self._project = project
+        self.project = project
 
     def chat(self):
         return Chat(self)

--- a/client.py
+++ b/client.py
@@ -12,7 +12,7 @@ def loads_if_json(data):
 
 class PromptArgs(BaseModel):
     name: str
-    label: str
+    label: str | None = None
     version: str | None = None
 
 
@@ -26,7 +26,7 @@ def prepare_prompt(project, args, placeholders=[]) -> PromptConfig:
     prompt_config = PromptConfig(
         args=PromptArgs(
             name=args["name"],
-            label=args["label"],
+            label=args.get("label"),
             version=args.get("version"),
         ),
         project=project,

--- a/client.py
+++ b/client.py
@@ -178,7 +178,7 @@ class ChatRequest(BaseModel):
     metadata: dict
 
 
-class Chat:
+class _Chat:
     def __init__(self, overlord):
         self.session_id = f"overlord_{uuid.uuid4()}"
         self._overlord = overlord
@@ -205,7 +205,7 @@ class Chat:
         if isinstance(prompt_data, dict):
             is_new_lf_prompt = self._handle_lf_prompt_config(prompt_data)
         elif not self._active_lf_prompt_config:
-            raise ValueError("Chat must be initialized with a Langfuse prompt config!")
+            raise ValueError("A chat must be initialized with a Langfuse prompt config!")
 
         chat_request = ChatRequest(
             lf_prompt_config=self._active_lf_prompt_config or self._initial_lf_prompt_config,  # fallback to first lf prompt
@@ -269,7 +269,7 @@ class Overlord:
         self.project = project
 
     def chat(self):
-        return Chat(self)
+        return _Chat(self)
 
     def task(self, data):
         chat = self.chat()

--- a/client.py
+++ b/client.py
@@ -1,8 +1,6 @@
-import requests, json, contextlib, os, uuid
+import requests, json, contextlib, uuid
 from typing import Literal, Generator
 from pydantic import BaseModel
-
-from langfuse import Langfuse
 
 
 def loads_if_json(data):

--- a/client.py
+++ b/client.py
@@ -221,6 +221,7 @@ class Chat:
         self._endpoint = "ai/chat"
         self._session_id = f"overlord_{uuid.uuid4()}"
         self._message_history = []
+        self._initial_lf_prompt_config = None
         self._initial_json_schema = None
         self._active_lf_prompt_config = None
 
@@ -242,7 +243,7 @@ class Chat:
             is_new_lf_prompt = self._handle_lf_prompt_config(prompt_data)
 
         chat_request = ChatRequest(
-            lf_prompt_config=self._active_lf_prompt_config,
+            lf_prompt_config=self._active_lf_prompt_config or self._initial_lf_prompt_config,
             is_new_lf_prompt=is_new_lf_prompt,
             text_prompt=None if isinstance(prompt_data, dict) else prompt_data,
             message_history=self._message_history,
@@ -259,6 +260,7 @@ class Chat:
 
         # only set json schema from first lf prompt
         if not self._message_history:
+            self._initial_lf_prompt_config = self._active_lf_prompt_config
             self._initial_json_schema = response["schema"]
 
         self._message_history = response["messages"]

--- a/client.py
+++ b/client.py
@@ -272,4 +272,6 @@ class Overlord:
         return Chat(self)
 
     def task(self, data):
-        return self.chat().request(data)
+        chat = self.chat()
+        chat.session_id = None
+        return chat.request(data)

--- a/client.py
+++ b/client.py
@@ -241,6 +241,8 @@ class Chat:
         is_new_lf_prompt = False
         if isinstance(prompt_data, dict):
             is_new_lf_prompt = self._handle_lf_prompt_config(prompt_data)
+        elif not self._active_lf_prompt_config:
+            raise ValueError("Chat must be initialized with a Langfuse prompt config!")
 
         chat_request = ChatRequest(
             lf_prompt_config=self._active_lf_prompt_config or self._initial_lf_prompt_config,  # fallback to first lf prompt
@@ -258,7 +260,6 @@ class Chat:
             self._active_lf_prompt_config = None  # reset for clean retry
             raise
 
-        # only set json schema from first lf prompt
         if not self._message_history:
             self._initial_lf_prompt_config = self._active_lf_prompt_config
             self._initial_json_schema = response["schema"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 fastapi==0.115.12
 uvicorn==0.34.0
 sse_starlette==2.2.1
+slowapi==0.1.9
 requests==2.32.3
 langfuse>=2.60.2
 litellm>=1.64.1
-slowapi==0.1.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ fastapi==0.115.12
 uvicorn==0.34.0
 sse_starlette==2.2.1
 requests==2.32.3
-langfuse==2.60.2
-litellm==1.64.1
+langfuse>=2.60.2
+litellm>=1.64.1
 slowapi==0.1.9

--- a/src/chat.py
+++ b/src/chat.py
@@ -2,18 +2,8 @@ from pydantic import BaseModel
 from src.utils.schema_to_model import transform
 from src.services import langfuse, litellm
 
-# NOTE:
-# - where do I get the params from?? model etc. etc. - should be stored from langfuse prompt in client!!
-# - what json schema / response_format should be used for chat messages? same as lf prompt's throughout or none or new?
 
-# - possibly it should not be either ChatData or PromptConfig but rather ChatData always containing PromptConfig but either with or without messages
-#   - but then I could just set the prompt again
-#   - I feel like I am spinning in circles and am confused...
-
-# so should I be storing the session id with the langfuse prompt in client to track the various chats?
-
-
-class ChatData(BaseModel):
+class ChatRequest(BaseModel):
     lf_prompt_config: langfuse.PromptConfig
     is_new_lf_prompt: bool
     # ---
@@ -45,7 +35,33 @@ def _handle_multimodal_messages(prompt, urls):
     return prompt
 
 
-async def call(data: ChatData):
+def handle_messages(
+    params,
+    lf_prompt,
+    lf_prompt_config,
+    is_new_lf_prompt,
+    text_prompt,
+    file_urls,
+) -> list[dict]:
+    # --- EITHER USE LANGFUSE PROMPT IF NEW OR TEXT PROMPT
+
+    if is_new_lf_prompt:
+        messages = lf_prompt.compile(**(lf_prompt_config.placeholders or {}))
+        params["metadata"]["prompt"] = lf_prompt  # enable prompt management via litellm metadata
+
+        if isinstance(messages, str):
+            messages = [{"role": "user", "content": messages}]
+
+    elif isinstance(text_prompt, str):
+        messages = [{"role": "user", "content": text_prompt}]
+
+    if file_urls:
+        messages = _handle_multimodal_messages(messages, file_urls)
+
+    return messages
+
+
+async def call(data: ChatRequest):
     lf_prompt_config = data.lf_prompt_config
     is_new_lf_prompt = data.is_new_lf_prompt
     text_prompt = data.text_prompt
@@ -68,27 +84,16 @@ async def call(data: ChatData):
     # schema = data.json_schema or params.pop("json_schema", None)
     schema = params.pop("json_schema", None)
 
-    print(type(text_prompt).__name__)
-    print(is_new_lf_prompt)
-
-    # --- EITHER USE LANGFUSE PROMPT IF NEW OR TEXT PROMPT
-
-    if is_new_lf_prompt:
-        messages = lf_prompt.compile(**(lf_prompt_config.placeholders or {}))
-        params["metadata"]["prompt"] = lf_prompt  # enable prompt management via litellm metadata
-
-        if isinstance(messages, str):
-            messages = [{"role": "user", "content": messages}]
-
-    elif isinstance(text_prompt, str):
-        messages = [{"role": "user", "content": text_prompt}]
-
-    if file_urls:
-        messages = _handle_multimodal_messages(messages, file_urls)
-
-    message_history += messages
-
     # ---
+
+    message_history += handle_messages(
+        params,
+        lf_prompt,
+        lf_prompt_config,
+        is_new_lf_prompt,
+        text_prompt,
+        file_urls,
+    )
 
     # build litellm standardized prompt message history
     params["messages"] = message_history

--- a/src/chat.py
+++ b/src/chat.py
@@ -1,0 +1,109 @@
+from src.services import langfuse, litellm
+
+from langfuse.model import PromptClient
+from src.utils.schema_to_model import transform
+
+from pydantic import BaseModel
+import uuid
+
+
+class ChatConfig(BaseModel):
+    chat_id: str
+    prompt_config: langfuse.PromptConfig
+
+
+def handle_response_format(json_schema):
+    if isinstance(json_schema, dict):
+        response_format: BaseModel = transform(json_schema)
+        return response_format
+
+    elif isinstance(json_schema, str):
+        # return {"type", "json_object"}
+        raise Exception("Json mode is not supported! Please use structured responses instead.")
+
+
+def _handle_multimodal_messages(prompt, urls):
+    for message in prompt:
+        if message["role"] == "user":
+            multimodal_messages = [{"type": "text", "text": message["content"]}]
+            for url in urls:
+                multimodal_messages.append({"type": "image_url", "image_url": url})
+            message["content"] = multimodal_messages
+
+    return prompt
+
+
+def handle_messages(prompt: PromptClient, placeholders: dict):
+    # pop urls from params to send as multi-modal messages
+    file_urls = placeholders.pop("file_urls", None)
+
+    compiled_prompt = prompt.compile(**placeholders)
+
+    if isinstance(compiled_prompt, str):
+        # turn single user prompt to message
+        compiled_prompt = [{"role": "user", "content": compiled_prompt}]
+
+    if file_urls:
+        compiled_prompt = _handle_multimodal_messages(compiled_prompt, file_urls)
+
+    return compiled_prompt
+
+
+class Chat:
+    instances: dict = {}
+
+    async def __init__(self, messages):
+        self.history = messages
+
+    @classmethod
+    async def _setup(cls, config: langfuse.PromptConfig):
+        chat_id = str(uuid.uuid4())
+        cls.instances[chat_id] = await cls(config)
+        return chat_id
+
+    @classmethod
+    def _grab_instance(cls, chat_id):
+        if chat_id in cls.instances:
+            return cls.instances[chat_id]
+
+    def _construct_litellm_args(self, langfuse_prompt, metadata):
+        args = langfuse_prompt.config.copy()
+
+        # pop json schema from params and turn into model
+        schema = args.pop("json_schema", None)
+
+        # enable prompt management via litellm metadata
+        args["metadata"] = {"prompt": langfuse_prompt}
+
+        # build litellm standard prompt
+        args["messages"] = self.history
+
+        # convert json schema to structured response format
+        if schema:
+            args["response_format"] = handle_response_format(schema)
+
+        # add custom metadata to generic from prompt
+        if metadata:
+            args["metadata"]["custom"] = metadata
+
+        return args
+
+    async def _get_response(self, args):
+        response = await litellm.call(**args)
+        self.history.append(dict(role="assistant", content=response))
+        return response
+
+    @classmethod
+    async def call(cls, config: ChatConfig):
+        chat_id = config.chat_id
+        prompt_config = config.prompt
+
+        placeholders = prompt_config.placeholders
+        metadata = prompt_config.metadata
+        messages = handle_messages(langfuse_prompt, placeholders)
+
+        langfuse_prompt = await langfuse.fetch_prompt(prompt_config)
+
+        chat = cls._grab_instance(chat_id) if chat_id else await cls._setup(messages)
+        args = chat._construct_litellm_args(langfuse_prompt, metadata)
+        return await chat._get_response(args)

--- a/src/endpoints/ai.py
+++ b/src/endpoints/ai.py
@@ -1,16 +1,15 @@
 from fastapi import APIRouter
-from fastapi.concurrency import run_in_threadpool
 
 from src.security import auth
 from src.core import sse
-from src.services import langfuse, litellm
+
+from src.chat import ChatRequest, call
 
 
-router = APIRouter(prefix="/langfuse")
+router = APIRouter(prefix="/ai")
 
 
-@router.post("/litellm", dependencies=[auth.via_api_key])
+@router.post("/chat", dependencies=[auth.via_api_key])
 @sse.endpoint
-async def langfuse_litellm(request: langfuse.PromptConfig):
-    func, args = langfuse.track(litellm.call), request
-    return await func(args)
+async def chat(request: ChatRequest):
+    return await call(request)

--- a/src/services/langfuse.py
+++ b/src/services/langfuse.py
@@ -46,13 +46,3 @@ class ClientManager:
 async def fetch_prompt(prompt_config: PromptConfig) -> PromptClient:
     lf = ClientManager.get_client(prompt_config.project)
     return await run_in_threadpool(lf.get_prompt, **prompt_config.args.model_dump())
-
-
-# I still feel like there is a limitation of using the litellm langfuse integration
-# as it requires to always send a langfuse prompt object to the metadata in order to
-# track it but what if I want to observe an external prompt via langfuse and call via
-# litellm e.g. in a chat bot scenario where only the inital prompt might be coming
-# from langfuse but the following from the user which then are linked via session id
-
-# what if the prompt config does not need to be sent as long as the inital generation
-# is linked to the following chat messages via the trace id?

--- a/src/services/langfuse.py
+++ b/src/services/langfuse.py
@@ -19,7 +19,7 @@ class PromptArgs(BaseModel):
 class PromptConfig(BaseModel):
     args: PromptArgs
     placeholders: dict = {}
-    _project: str
+    project: str
 
 
 # HELPER
@@ -44,5 +44,5 @@ class ClientManager:
 
 
 async def fetch_prompt(prompt_config: PromptConfig) -> PromptClient:
-    lf = ClientManager.get_client(prompt_config._project)
+    lf = ClientManager.get_client(prompt_config.project)
     return await run_in_threadpool(lf.get_prompt, **prompt_config.args.model_dump())

--- a/src/services/langfuse.py
+++ b/src/services/langfuse.py
@@ -18,8 +18,8 @@ class PromptArgs(BaseModel):
 
 class PromptConfig(BaseModel):
     args: PromptArgs
-    project: str
     placeholders: dict = {}
+    _project: str
 
 
 # HELPER
@@ -44,5 +44,5 @@ class ClientManager:
 
 
 async def fetch_prompt(prompt_config: PromptConfig) -> PromptClient:
-    lf = ClientManager.get_client(prompt_config.project)
+    lf = ClientManager.get_client(prompt_config._project)
     return await run_in_threadpool(lf.get_prompt, **prompt_config.args.model_dump())

--- a/src/services/langfuse.py
+++ b/src/services/langfuse.py
@@ -13,13 +13,13 @@ import os
 class PromptArgs(BaseModel):
     name: str
     label: str
-    version: str = None
+    version: str | None = None
 
 
 class PromptConfig(BaseModel):
     args: PromptArgs
-    placeholders: dict | None = None
-    # metadata: dict | None = None
+    project: str
+    placeholders: dict = {}
 
 
 # HELPER
@@ -43,9 +43,9 @@ class ClientManager:
         return cls.clients[project]
 
 
-async def fetch_prompt(prompt_args: PromptArgs) -> PromptClient:
-    lf = ClientManager.get_client(prompt_args.pop("project"))
-    return await run_in_threadpool(lf.get_prompt, **prompt_args)  # possibly pass project as separate param/arg
+async def fetch_prompt(prompt_config: PromptConfig) -> PromptClient:
+    lf = ClientManager.get_client(prompt_config.project)
+    return await run_in_threadpool(lf.get_prompt, **prompt_config.args.model_dump())
 
 
 # I still feel like there is a limitation of using the litellm langfuse integration

--- a/src/services/langfuse.py
+++ b/src/services/langfuse.py
@@ -12,7 +12,7 @@ import os
 
 class PromptArgs(BaseModel):
     name: str
-    label: str
+    label: str | None = None
     version: str | None = None
 
 

--- a/src/services/langfuse.py
+++ b/src/services/langfuse.py
@@ -2,7 +2,6 @@ from langfuse import Langfuse
 from langfuse.model import PromptClient
 
 from pydantic import BaseModel
-from src.utils.schema_to_model import transform
 
 from fastapi.concurrency import run_in_threadpool
 import os
@@ -11,10 +10,16 @@ import os
 # DATA
 
 
+class PromptArgs(BaseModel):
+    name: str
+    label: str
+    version: str = None
+
+
 class PromptConfig(BaseModel):
-    args: dict
+    args: PromptArgs
     placeholders: dict | None = None
-    metadata: dict | None = None
+    # metadata: dict | None = None
 
 
 # HELPER
@@ -38,79 +43,16 @@ class ClientManager:
         return cls.clients[project]
 
 
-async def fetch_prompt(prompt_config: PromptConfig):
-    lf = ClientManager.get_client(prompt_config.args.pop("project"))
-    return await run_in_threadpool(lf.get_prompt, **prompt_config.args)
+async def fetch_prompt(prompt_args: PromptArgs) -> PromptClient:
+    lf = ClientManager.get_client(prompt_args.pop("project"))
+    return await run_in_threadpool(lf.get_prompt, **prompt_args)  # possibly pass project as separate param/arg
 
 
-def handle_response_format(json_schema):
-    if isinstance(json_schema, dict):
-        response_format: BaseModel = transform(json_schema)
-        return response_format
+# I still feel like there is a limitation of using the litellm langfuse integration
+# as it requires to always send a langfuse prompt object to the metadata in order to
+# track it but what if I want to observe an external prompt via langfuse and call via
+# litellm e.g. in a chat bot scenario where only the inital prompt might be coming
+# from langfuse but the following from the user which then are linked via session id
 
-    elif isinstance(json_schema, str):
-        # return {"type", "json_object"}
-        raise Exception("Json mode is not supported! Please use structured responses instead.")
-
-
-def _handle_multimodal_messages(prompt, urls):
-    for message in prompt:
-        if message["role"] == "user":
-            multimodal_messages = [{"type": "text", "text": message["content"]}]
-            for url in urls:
-                multimodal_messages.append({"type": "image_url", "image_url": url})
-            message["content"] = multimodal_messages
-
-    return prompt
-
-
-def handle_messages(prompt: PromptClient, placeholders: dict):
-    # pop urls from params to send as multi-modal messages
-    file_urls = placeholders.pop("file_urls", None)
-
-    compiled_prompt = prompt.compile(**placeholders)
-
-    if isinstance(compiled_prompt, str):
-        # turn single user prompt to message
-        compiled_prompt = [{"role": "user", "content": compiled_prompt}]
-
-    if file_urls:
-        compiled_prompt = _handle_multimodal_messages(compiled_prompt, file_urls)
-
-    return compiled_prompt
-
-
-# MAIN
-
-
-def track(func):
-    async def wrapper(prompt_config: PromptConfig):
-        # get or init client and get prompt object
-        prompt = await fetch_prompt(prompt_config)
-
-        # extract prompt placeholders and litellm params
-        placeholders = prompt_config.placeholders or {}
-        params = prompt.config.copy()
-
-        # pop json schema from params and turn into model
-        schema = params.pop("json_schema", None)
-
-        # enable prompt management via litellm metadata
-        params["metadata"] = {"prompt": prompt}
-
-        # ---
-
-        # build litellm standard prompt
-        params["messages"] = handle_messages(prompt, placeholders)
-
-        # convert json schema to structured response format
-        if schema:
-            params["response_format"] = handle_response_format(schema)
-
-        # add custom metadata to generic from prompt
-        if prompt_config.metadata:
-            params["metadata"]["custom"] = prompt_config.metadata
-
-        return await func(**params)
-
-    return wrapper
+# what if the prompt config does not need to be sent as long as the inital generation
+# is linked to the following chat messages via the trace id?


### PR DESCRIPTION
Complete overhaul of the main endpoint to `ai/chat` as well as client-side chat state handling.

Refer to the client documentation in the readme for usage explanation.

## API
- takes in ChatRequest which will:
  - either include the langfuse prompt config that the chat was initialized with or a new langfuse prompt config to continue the chat
  - include the chat message history if it is not the first message
- returns the chat message history along with the schema if it is provided or None

> it is not as clean as before where only the langfuse prompt was input and the response was returned _but_ it seems to be the only way (at least for now) to allow chatting as we now have the options to chat with an initial langfuse prompt using simple text prompts that a user inputs and trace those in an e.g. chat bot application

- langfuse observability is still handled via sending the prompt as dict to litellm

## Client
- removed the langfuse package dependency which was only used for creating prompts but not actually added anything useful to the base prompt creation so now just go through the base langfuse sdk prompt creation method described in the official docs
- wrapped request into a clean method for chatting as well as for a single task type of prompt