### PR TITLE
Switch to global app auth instead of endpoint specific

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ from src.security import auth, limits, cors
 from src.endpoints import ai, test
 
 
-app = FastAPI()
+app = FastAPI(dependencies=[auth.via_api_key])
 
 app.include_router(ai.router)
 app.include_router(test.router)
@@ -18,6 +18,6 @@ limits.setup(app, rates)
 logging.setup(app, name)
 
 
-@app.get("/", dependencies=[auth.via_api_key])
+@app.get("/")
 def health_check():
     return Response(f"{name} is awake")

--- a/src/endpoints/ai.py
+++ b/src/endpoints/ai.py
@@ -9,7 +9,7 @@ from src.chat import ChatRequest, call
 router = APIRouter(prefix="/ai")
 
 
-@router.post("/chat", dependencies=[auth.via_api_key])
+@router.post("/chat")
 @sse.endpoint
 async def chat(request: ChatRequest):
     return await call(request)

--- a/src/endpoints/test.py
+++ b/src/endpoints/test.py
@@ -10,7 +10,7 @@ import uuid
 router = APIRouter(prefix="/test")
 
 
-@router.post("/gen_uuid", dependencies=[auth.via_api_key])
+@router.post("/gen_uuid")
 @sse.endpoint
 async def _():
     return await run_in_threadpool(lambda: str(uuid.uuid4()))


### PR DESCRIPTION
Now the app and creation uses the api key auth dependency removing it from every endpoint.