### PR TITLE
Higher rate limits for high-usage clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@
 APP_NAME="my-overlord"
 ACCESS_KEYS='["example-secret-key-one", "example-secret-key-two", "example-secret-key-three"]'
 ALLOWED_ORIGINS='["https://www.example.com/"]'
-RATE_LIMITS='["1/second", "10/minute", "100/day"]'
+RATE_LIMITS_DEFAULT='["1/second", "10/minute", "100/hour", "1000/day"]'
+RATE_LIMITS_HIGH='["10/second", "100/minute", "1000/hour", "10000/day"]'  # only needed if high-usage client required
 
 # various langfuse project keys
 LANGFUSE_SECRET_KEY_PROJECT="your-langfuse-secret-key-with-the-project-name"
@@ -82,7 +83,7 @@ Run `pip install requests pydantic`
 from overlordapi import Overlord
 
 
-overlord = Overlord("http://your-server.url", "your-api-key", "your-langfuse-project")
+overlord = Overlord("http://your-server.url", "your-api-key", "your-langfuse-project", client_type="high-usage")  # or "default" client_type
 
 # health check (optional)
 print(overlord.client.ping().text)

--- a/config.py
+++ b/config.py
@@ -6,8 +6,8 @@ load_dotenv(dotenv_path=".env", override=True)
 
 
 name = os.getenv("APP_NAME", "overlord")
-access_keys = json.loads(os.getenv("ACCESS_KEYS", "[]"))
 origins = json.loads(os.getenv("ALLOWED_ORIGINS", "[]"))
+access_keys = json.loads(os.getenv("ACCESS_KEYS", "[]"))
 
 if not access_keys:
     raise ValueError("No access keys are set!")
@@ -17,8 +17,6 @@ rate_limits_high = json.loads(os.getenv("RATE_LIMITS_HIGH", "[]"))
 
 if not rate_limits_default:
     raise ValueError("No default rate limits are set!")
-
-# Use default limits for high-usage if not specified
 if not rate_limits_high:
     rate_limits_high = rate_limits_default
 

--- a/config.py
+++ b/config.py
@@ -8,12 +8,24 @@ load_dotenv(dotenv_path=".env", override=True)
 name = os.getenv("APP_NAME", "overlord")
 access_keys = json.loads(os.getenv("ACCESS_KEYS", "[]"))
 origins = json.loads(os.getenv("ALLOWED_ORIGINS", "[]"))
-rates = json.loads(os.getenv("RATE_LIMITS", "[]"))
 
 if not access_keys:
     raise ValueError("No access keys are set!")
-if not rates:
-    raise ValueError("No rate limits are set!")
+
+rate_limits_default = json.loads(os.getenv("RATE_LIMITS_DEFAULT", "[]"))
+rate_limits_high = json.loads(os.getenv("RATE_LIMITS_HIGH", "[]"))
+
+if not rate_limits_default:
+    raise ValueError("No default rate limits are set!")
+
+# Use default limits for high-usage if not specified
+if not rate_limits_high:
+    rate_limits_high = rate_limits_default
+
+rates = {
+    "default": rate_limits_default,
+    "high-usage": rate_limits_high,
+}
 
 
 litellm.success_callback = ["langfuse"]

--- a/main.py
+++ b/main.py
@@ -9,13 +9,16 @@ from src.endpoints import ai, test
 
 app = FastAPI(dependencies=[auth.via_api_key])
 
-app.include_router(ai.router)
-app.include_router(test.router)
 
-
+# setup security middlewares
 cors.setup(app, origins)
 limits.setup(app, rates)
 logging.setup(app, name)
+
+
+# include module routers
+app.include_router(ai.router)
+app.include_router(test.router)
 
 
 @app.get("/")

--- a/src/security/cors.py
+++ b/src/security/cors.py
@@ -8,5 +8,5 @@ def setup(app: FastAPI, allowed_origins: list[str]):
         allow_origins=allowed_origins,
         allow_credentials=False,
         allow_methods=["GET", "POST"],
-        allow_headers=["x-api-key", "content-type"],
+        allow_headers=["x-api-key", "x-client-type", "content-type"],
     )

--- a/src/security/limits.py
+++ b/src/security/limits.py
@@ -1,12 +1,55 @@
-from fastapi import FastAPI
-
-from slowapi import Limiter, _rate_limit_exceeded_handler
-from slowapi.util import get_remote_address
-from slowapi.middleware import SlowAPIMiddleware
-from slowapi.errors import RateLimitExceeded
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+import time
+from collections import defaultdict
 
 
-def setup(app: FastAPI, rates: list[str]):
-    app.state.limiter = Limiter(key_func=get_remote_address, default_limits=rates)
-    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
-    app.add_middleware(SlowAPIMiddleware)
+def setup(app: FastAPI, rate_configs: dict[str, list[str]]):
+    """
+    Setup rate limiting based on x-client-type header.
+
+    Example: {"default": ["1/second"], "high-usage": ["10/second"]}
+    """
+
+    time_units = dict(
+        second=1,
+        minute=60,
+        hour=3600,
+        day=86400,
+    )
+
+    request_history = defaultdict(list)
+
+    def _is_rate_limit_exceeded(key: str, max_requests: int, window: int, now: float) -> bool:
+        "Remove old timestamps and check if limit exceeded."
+
+        request_history[key] = [t for t in request_history[key] if t > (now - window)]
+        return len(request_history[key]) >= max_requests
+
+    def _cleanup_history_if_needed(key: str, max_requests: int) -> None:
+        "Prevent memory leak by limiting history size."
+
+        if len(request_history[key]) > max_requests * 2:
+            request_history[key] = request_history[key][-max_requests:]
+
+    @app.middleware("http")
+    async def rate_limit_middleware(request: Request, call_next):
+        # get client identity
+        ip, client_type = request.client.host or "unknown", request.headers.get("x-client-type", "default")
+
+        limits = rate_configs.get(client_type, rate_configs["default"])
+        now = time.time()
+
+        # check whether any limit is exceeded
+        for limit in limits:
+            max_requests, unit = limit.split("/")
+            max_requests = int(max_requests)
+            key = f"{client_type}:{ip}:{limit}"
+
+            if _is_rate_limit_exceeded(key, max_requests, time_units[unit], now):
+                return JSONResponse(status_code=429, content={"detail": f"Rate limit exceeded: {limit}"})
+
+            request_history[key].append(now)
+            _cleanup_history_if_needed(key, max_requests)
+
+        return await call_next(request)

--- a/src/services/langfuse.py
+++ b/src/services/langfuse.py
@@ -18,7 +18,7 @@ class PromptArgs(BaseModel):
 
 class PromptConfig(BaseModel):
     args: PromptArgs
-    placeholders: dict = {}
+    placeholders: dict | None = None
     project: str
 
 


### PR DESCRIPTION
A new header `x-client-type` was added that can be set to `high-usage` or `default` and will use different rate limits if they are set in the secrets:

```env
RATE_LIMITS_DEFAULT='["1/second", "10/minute", "100/hour", "1000/day"]'
RATE_LIMITS_HIGH='["10/second", "100/minute", "1000/hour", "10000/day"]' 
```

The client can now be initialized with the `client_type` set or be left out which will use the default:

```python
overlord = Overlord(
    server,
    api_key,
    project,
    client_type="high-usage",
)
```