### PR TITLE
Set client timeout and ensure langfuse v2

### DIFF
--- a/client.py
+++ b/client.py
@@ -47,14 +47,15 @@ class _Client:
     ```
     """
 
-    def __init__(self, server: str, api_key: str, client_type: str):
+    def __init__(self, server: str, api_key: str, client_type: str, timeout: int = 60):
         if not server:
             raise OverlordClientError("No server url specified!")
         if not api_key:
             raise OverlordClientError("No api key specified!")
 
         self._server = server
-        self._client = httpx.AsyncClient()
+        # Set a longer timeout for AI operations (default is 5 seconds)
+        self._client = httpx.AsyncClient(timeout=httpx.Timeout(timeout))
 
         self._auth(api_key)
         self._set_client_type_header(client_type or "default")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ uvicorn==0.34.0
 sse_starlette==2.2.1
 slowapi==0.1.9
 httpx==0.28.1
-langfuse>=2.60.2
+langfuse>=2,<3
 litellm>=1.70.0


### PR DESCRIPTION
[Increase httpx timeout to default one minute for long ai requests](https://github.com/emilrueh/overlord/commit/1f2e3a5d9916950034e1e259695adc94a8535ebb)

[Ensure langfuse v2 as v3 breaks litellm](https://github.com/emilrueh/overlord/commit/2c32c2e248081fafaadec4cabe5ffb4643d306a4)